### PR TITLE
fix(example): metro bundler error

### DIFF
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -7,6 +7,7 @@ module.exports = {
     [
       'module-resolver',
       {
+        extensions: ['.js', '.ts', '.json', '.jsx', '.tsx'],
         alias: {
           [pak.name]: path.join(__dirname, '..', 'src/index'),
         },


### PR DESCRIPTION
fix metro bundler error that `transform[stderr]: Could not resolve ~~~`