### PR TITLE
Refs. #34 delete listener properties when removed

### DIFF
--- a/__tests__/blueveryListener.test.ts
+++ b/__tests__/blueveryListener.test.ts
@@ -57,6 +57,7 @@ describe('BlueveryListener', () => {
         'receivingForCharacteristicValueListener',
       );
 
+      expect(blueveryListener.publicListeners).toStrictEqual({1: {}});
       expect(mockEmitter.remove).toBeCalledTimes(1);
     });
   });
@@ -84,6 +85,7 @@ describe('BlueveryListener', () => {
 
       blueveryListener.removePeripheralPublicSubscription('1');
 
+      expect(blueveryListener.publicListeners).toStrictEqual({});
       expect(mockEmitter1.remove).toHaveBeenCalledTimes(1);
       expect(mockEmitter2.remove).toHaveBeenCalledTimes(1);
     });
@@ -125,6 +127,8 @@ describe('BlueveryListener', () => {
 
       blueveryListener.removeAllSubscriptions();
 
+      expect(blueveryListener.internalListeners).toStrictEqual({});
+      expect(blueveryListener.publicListeners).toStrictEqual({});
       expect(mockEmitter1.remove).toHaveBeenCalledTimes(1);
       expect(mockEmitter2.remove).toHaveBeenCalledTimes(1);
       expect(mockEmitter3.remove).toHaveBeenCalledTimes(1);

--- a/src/blueveryListeners.ts
+++ b/src/blueveryListeners.ts
@@ -31,7 +31,11 @@ export class BlueveryListeners {
     peripheralId: PeripheralId,
     key: Key,
   ) {
-    this.publicListeners[peripheralId]?.[key]?.remove();
+    const subscription = this.publicListeners[peripheralId]?.[key];
+    if (subscription) {
+      subscription.remove();
+      delete this.publicListeners[peripheralId]?.[key];
+    }
   }
 
   removePeripheralPublicSubscription(peripheralId: PeripheralId) {
@@ -41,12 +45,14 @@ export class BlueveryListeners {
         listener?.remove();
       });
     }
+    delete this.publicListeners[peripheralId];
   }
 
   removeAllSubscriptions() {
     Object.values(this.internalListeners).forEach((listener) => {
       listener?.remove();
     });
+    this.internalListeners = {};
     Object.values(this.publicListeners).forEach((subscriptions) => {
       if (subscriptions) {
         Object.values(subscriptions).forEach((listener) => {
@@ -54,5 +60,6 @@ export class BlueveryListeners {
         });
       }
     });
+    this.publicListeners = {};
   }
 }


### PR DESCRIPTION
# 変更内容
src/blueveryListeners.ts での subscripton remove時に、remove された publicListeners or  internalListeners のキーを削除するようにした。

# 動作確認
iOSシミュレーターで Exampleの hookを複数回 mount/unmountを繰り返し、エラーが発生しないことを確認した。

# Note
publicListeners, internalListeners をこのクラス内に隠蔽したかったが一部外部で利用されているため断念。
(subscriptionの購読と解除のためのデータは外部から変更されると危険なため、可能な限り隠蔽したい)

また、これらを readonly にしたかったが、Object.entires.forEach([key,value]) で internalListeners[key] の特定プロパティだけを削除できなかったため、こちらも一旦、保留した。(internalListeners は type で項目名が一意の名前に決まっているのに、key が string型であるため型ミスマッチになる模様)