### PR TITLE
Example for A&D UC-352BLE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ dist
 .pnp.*
 
 
+.DS_Store

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -16,14 +16,15 @@ target 'example' do
 
   target 'exampleTests' do
     inherit! :complete
-    # Pods for testing
+    # Pods for testingd
   end
 
   # Enables Flipper.
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
+  #use_flipper!
+  use_flipper!({ 'Flipper-Folly' => '2.5.3', 'Flipper' => '0.87.0', 'Flipper-RSocket' => '1.3.1' })
   post_install do |installer|
     flipper_post_install(installer)
   end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -23,16 +23,15 @@ target 'example' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  #use_flipper!
   use_flipper!({ 'Flipper-Folly' => '2.5.3', 'Flipper' => '0.87.0', 'Flipper-RSocket' => '1.3.1' })
   post_install do |installer|
     flipper_post_install(installer)
   end
 
   permissions_path = '../node_modules/react-native-permissions/ios'
-  pod 'Permission-BluetoothPeripheral', :path => "#{permissions_path}/BluetoothPeripheral/Permission-BluetoothPeripheral.podspec"
-  pod 'Permission-LocationWhenInUse', :path => "#{permissions_path}/LocationWhenInUse/Permission-LocationWhenInUse.podspec"
-  pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications/Permission-Notifications.podspec"
+  pod 'Permission-BluetoothPeripheral', :path => "#{permissions_path}/BluetoothPeripheral"
+  pod 'Permission-LocationWhenInUse', :path => "#{permissions_path}/LocationWhenInUse"
+  pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications"
 
 end
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -29,9 +29,9 @@ target 'example' do
   end
 
   permissions_path = '../node_modules/react-native-permissions/ios'
-  pod 'Permission-BluetoothPeripheral', :path => "#{permissions_path}/BluetoothPeripheral.podspec"
-  pod 'Permission-LocationWhenInUse', :path => "#{permissions_path}/LocationWhenInUse.podspec"
-  pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications.podspec"
+  pod 'Permission-BluetoothPeripheral', :path => "#{permissions_path}/BluetoothPeripheral/Permission-BluetoothPeripheral.podspec"
+  pod 'Permission-LocationWhenInUse', :path => "#{permissions_path}/LocationWhenInUse/Permission-LocationWhenInUse.podspec"
+  pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications/Permission-Notifications.podspec"
 
 end
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -16,7 +16,7 @@ target 'example' do
 
   target 'exampleTests' do
     inherit! :complete
-    # Pods for testingd
+    # Pods for testing
   end
 
   # Enables Flipper.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -85,11 +85,11 @@ PODS:
   - OpenSSL-Universal (1.0.2.20):
     - OpenSSL-Universal/Static (= 1.0.2.20)
   - OpenSSL-Universal/Static (1.0.2.20)
-  - Permission-BluetoothPeripheral (2.2.2):
+  - Permission-BluetoothPeripheral (3.0.4):
     - RNPermissions
-  - Permission-LocationWhenInUse (2.2.2):
+  - Permission-LocationWhenInUse (3.0.4):
     - RNPermissions
-  - Permission-Notifications (2.2.2):
+  - Permission-Notifications (3.0.4):
     - RNPermissions
   - RCTRequired (0.63.2)
   - RCTTypeSafety (0.63.2):
@@ -327,7 +327,7 @@ PODS:
     - React
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNPermissions (2.2.2):
+  - RNPermissions (3.0.4):
     - React-Core
   - RNReanimated (2.1.0):
     - DoubleConversion
@@ -418,9 +418,9 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (~> 0.41.1)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral.podspec`)
-  - Permission-LocationWhenInUse (from `../node_modules/react-native-permissions/ios/LocationWhenInUse.podspec`)
-  - Permission-Notifications (from `../node_modules/react-native-permissions/ios/Notifications.podspec`)
+  - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral/Permission-BluetoothPeripheral.podspec`)
+  - Permission-LocationWhenInUse (from `../node_modules/react-native-permissions/ios/LocationWhenInUse/Permission-LocationWhenInUse.podspec`)
+  - Permission-Notifications (from `../node_modules/react-native-permissions/ios/Notifications/Permission-Notifications.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
   - React (from `../node_modules/react-native/`)
@@ -504,11 +504,11 @@ EXTERNAL SOURCES:
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   Permission-BluetoothPeripheral:
-    :path: "../node_modules/react-native-permissions/ios/BluetoothPeripheral.podspec"
+    :path: "../node_modules/react-native-permissions/ios/BluetoothPeripheral/Permission-BluetoothPeripheral.podspec"
   Permission-LocationWhenInUse:
-    :path: "../node_modules/react-native-permissions/ios/LocationWhenInUse.podspec"
+    :path: "../node_modules/react-native-permissions/ios/LocationWhenInUse/Permission-LocationWhenInUse.podspec"
   Permission-Notifications:
-    :path: "../node_modules/react-native-permissions/ios/Notifications.podspec"
+    :path: "../node_modules/react-native-permissions/ios/Notifications/Permission-Notifications.podspec"
   RCTRequired:
     :path: "../node_modules/react-native/Libraries/RCTRequired"
   RCTTypeSafety:
@@ -618,9 +618,9 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
-  Permission-BluetoothPeripheral: 73e80c434beef6570ba7c322a6882a8d46c2c4d3
-  Permission-LocationWhenInUse: 871e81c06c1fc578353fce962d5d8e6efa697f1a
-  Permission-Notifications: 9c6b5cc4f0e6599e9fc3395b77cebddc48f1be41
+  Permission-BluetoothPeripheral: 742b306312f329b809e2f62e475b0b61b206962b
+  Permission-LocationWhenInUse: ebef6bf8a123d382f25e9990468cfc8a76fbadf5
+  Permission-Notifications: 5b4a12a9b52866667423c93d3af8e43b81872cf4
   RCTRequired: f13f25e7b12f925f1f6a6a8c69d929a03c0129fe
   RCTTypeSafety: 44982c5c8e43ff4141eb519a8ddc88059acd1f3a
   React: e1c65dd41cb9db13b99f24608e47dd595f28ca9a
@@ -646,7 +646,7 @@ SPEC CHECKSUMS:
   ReactCommon: a0a1edbebcac5e91338371b72ffc66aa822792ce
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNPermissions: 5df468064df661a4c8c017e2791ce90d7695eea5
+  RNPermissions: c46788f4cd402287425983e04a4c9bb4356036eb
   RNReanimated: 70f662b5232dd5d19ccff581e919a54ea73df51c
   RNScreens: c277bfc4b5bb7c2fe977d19635df6f974f95dfd6
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
@@ -666,6 +666,6 @@ SPEC CHECKSUMS:
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: bdfc89ff73b1b60c94804b18ba344d3cb3c48469
+PODFILE CHECKSUM: d1cd210d2ec526c73551aa5d838fe8ed61847e19
 
 COCOAPODS: 1.10.1

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -427,9 +427,9 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (= 0.87.0)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral/Permission-BluetoothPeripheral.podspec`)
-  - Permission-LocationWhenInUse (from `../node_modules/react-native-permissions/ios/LocationWhenInUse/Permission-LocationWhenInUse.podspec`)
-  - Permission-Notifications (from `../node_modules/react-native-permissions/ios/Notifications/Permission-Notifications.podspec`)
+  - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral`)
+  - Permission-LocationWhenInUse (from `../node_modules/react-native-permissions/ios/LocationWhenInUse`)
+  - Permission-Notifications (from `../node_modules/react-native-permissions/ios/Notifications`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
   - React (from `../node_modules/react-native/`)
@@ -513,11 +513,11 @@ EXTERNAL SOURCES:
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   Permission-BluetoothPeripheral:
-    :path: "../node_modules/react-native-permissions/ios/BluetoothPeripheral/Permission-BluetoothPeripheral.podspec"
+    :path: "../node_modules/react-native-permissions/ios/BluetoothPeripheral"
   Permission-LocationWhenInUse:
-    :path: "../node_modules/react-native-permissions/ios/LocationWhenInUse/Permission-LocationWhenInUse.podspec"
+    :path: "../node_modules/react-native-permissions/ios/LocationWhenInUse"
   Permission-Notifications:
-    :path: "../node_modules/react-native-permissions/ios/Notifications/Permission-Notifications.podspec"
+    :path: "../node_modules/react-native-permissions/ios/Notifications"
   RCTRequired:
     :path: "../node_modules/react-native/Libraries/RCTRequired"
   RCTTypeSafety:
@@ -675,6 +675,6 @@ SPEC CHECKSUMS:
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: bbfb81792b8f9c85a399d75cb55f86e66d317ab7
+PODFILE CHECKSUM: d365429634963b5414e1a50561eb6f54be317980
 
 COCOAPODS: 1.10.1

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,6 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - CocoaAsyncSocket (7.6.4)
-  - CocoaLibEvent (1.0.0)
+  - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - EXConstants (10.1.3):
     - UMConstantsInterface
@@ -26,50 +25,61 @@ PODS:
     - React-Core (= 0.63.2)
     - React-jsi (= 0.63.2)
     - ReactCommon/turbomodule/core (= 0.63.2)
-  - Flipper (0.41.5):
-    - Flipper-Folly (~> 2.2)
-    - Flipper-RSocket (~> 1.1)
+  - Flipper (0.87.0):
+    - Flipper-Folly (~> 2.5)
+    - Flipper-RSocket (~> 1.3)
   - Flipper-DoubleConversion (1.1.7)
-  - Flipper-Folly (2.3.0):
+  - Flipper-Folly (2.5.3):
     - boost-for-react-native
-    - CocoaLibEvent (~> 1.0)
     - Flipper-DoubleConversion
     - Flipper-Glog
-    - OpenSSL-Universal (= 1.0.2.20)
+    - libevent (~> 2.1.12)
+    - OpenSSL-Universal (= 1.1.180)
   - Flipper-Glog (0.3.6)
   - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.1.0):
-    - Flipper-Folly (~> 2.2)
-  - FlipperKit (0.41.5):
-    - FlipperKit/Core (= 0.41.5)
-  - FlipperKit/Core (0.41.5):
-    - Flipper (~> 0.41.5)
+  - Flipper-RSocket (1.3.1):
+    - Flipper-Folly (~> 2.5)
+  - FlipperKit (0.87.0):
+    - FlipperKit/Core (= 0.87.0)
+  - FlipperKit/Core (0.87.0):
+    - Flipper (~> 0.87.0)
     - FlipperKit/CppBridge
     - FlipperKit/FBCxxFollyDynamicConvert
     - FlipperKit/FBDefines
     - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.41.5):
-    - Flipper (~> 0.41.5)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.41.5):
-    - Flipper-Folly (~> 2.2)
-  - FlipperKit/FBDefines (0.41.5)
-  - FlipperKit/FKPortForwarding (0.41.5):
+  - FlipperKit/CppBridge (0.87.0):
+    - Flipper (~> 0.87.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (0.87.0):
+    - Flipper-Folly (~> 2.5)
+  - FlipperKit/FBDefines (0.87.0)
+  - FlipperKit/FKPortForwarding (0.87.0):
     - CocoaAsyncSocket (~> 7.6)
     - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.41.5)
-  - FlipperKit/FlipperKitLayoutPlugin (0.41.5):
+  - FlipperKit/FlipperKitHighlightOverlay (0.87.0)
+  - FlipperKit/FlipperKitLayoutHelpers (0.87.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutTextSearchable
+  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.87.0):
+    - FlipperKit/Core
+    - FlipperKit/FlipperKitHighlightOverlay
+    - FlipperKit/FlipperKitLayoutHelpers
     - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.41.5)
-  - FlipperKit/FlipperKitNetworkPlugin (0.41.5):
+  - FlipperKit/FlipperKitLayoutPlugin (0.87.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.41.5):
+    - FlipperKit/FlipperKitHighlightOverlay
+    - FlipperKit/FlipperKitLayoutHelpers
+    - FlipperKit/FlipperKitLayoutIOSDescriptors
+    - FlipperKit/FlipperKitLayoutTextSearchable
+    - YogaKit (~> 1.18)
+  - FlipperKit/FlipperKitLayoutTextSearchable (0.87.0)
+  - FlipperKit/FlipperKitNetworkPlugin (0.87.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.41.5):
+  - FlipperKit/FlipperKitReactPlugin (0.87.0):
     - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.41.5):
+  - FlipperKit/FlipperKitUserDefaultsPlugin (0.87.0):
+    - FlipperKit/Core
+  - FlipperKit/SKIOSNetworkPlugin (0.87.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitNetworkPlugin
   - Folly (2020.01.13.00):
@@ -82,9 +92,8 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - OpenSSL-Universal (1.0.2.20):
-    - OpenSSL-Universal/Static (= 1.0.2.20)
-  - OpenSSL-Universal/Static (1.0.2.20)
+  - libevent (2.1.12)
+  - OpenSSL-Universal (1.1.180)
   - Permission-BluetoothPeripheral (3.0.4):
     - RNPermissions
   - Permission-LocationWhenInUse (3.0.4):
@@ -397,25 +406,25 @@ DEPENDENCIES:
   - EXPermissions (from `../node_modules/expo-permissions/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
-  - Flipper (~> 0.41.1)
+  - Flipper (= 0.87.0)
   - Flipper-DoubleConversion (= 1.1.7)
-  - Flipper-Folly (~> 2.2)
+  - Flipper-Folly (= 2.5.3)
   - Flipper-Glog (= 0.3.6)
   - Flipper-PeerTalk (~> 0.0.4)
-  - Flipper-RSocket (~> 1.1)
-  - FlipperKit (~> 0.41.1)
-  - FlipperKit/Core (~> 0.41.1)
-  - FlipperKit/CppBridge (~> 0.41.1)
-  - FlipperKit/FBCxxFollyDynamicConvert (~> 0.41.1)
-  - FlipperKit/FBDefines (~> 0.41.1)
-  - FlipperKit/FKPortForwarding (~> 0.41.1)
-  - FlipperKit/FlipperKitHighlightOverlay (~> 0.41.1)
-  - FlipperKit/FlipperKitLayoutPlugin (~> 0.41.1)
-  - FlipperKit/FlipperKitLayoutTextSearchable (~> 0.41.1)
-  - FlipperKit/FlipperKitNetworkPlugin (~> 0.41.1)
-  - FlipperKit/FlipperKitReactPlugin (~> 0.41.1)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.41.1)
-  - FlipperKit/SKIOSNetworkPlugin (~> 0.41.1)
+  - Flipper-RSocket (= 1.3.1)
+  - FlipperKit (= 0.87.0)
+  - FlipperKit/Core (= 0.87.0)
+  - FlipperKit/CppBridge (= 0.87.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (= 0.87.0)
+  - FlipperKit/FBDefines (= 0.87.0)
+  - FlipperKit/FKPortForwarding (= 0.87.0)
+  - FlipperKit/FlipperKitHighlightOverlay (= 0.87.0)
+  - FlipperKit/FlipperKitLayoutPlugin (= 0.87.0)
+  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.87.0)
+  - FlipperKit/FlipperKitNetworkPlugin (= 0.87.0)
+  - FlipperKit/FlipperKitReactPlugin (= 0.87.0)
+  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.87.0)
+  - FlipperKit/SKIOSNetworkPlugin (= 0.87.0)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral/Permission-BluetoothPeripheral.podspec`)
@@ -471,7 +480,6 @@ SPEC REPOS:
   trunk:
     - boost-for-react-native
     - CocoaAsyncSocket
-    - CocoaLibEvent
     - Flipper
     - Flipper-DoubleConversion
     - Flipper-Folly
@@ -479,6 +487,7 @@ SPEC REPOS:
     - Flipper-PeerTalk
     - Flipper-RSocket
     - FlipperKit
+    - libevent
     - OpenSSL-Universal
     - YogaKit
 
@@ -598,8 +607,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
-  CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
+  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXConstants: c4dd28acc12039c999612507a5f935556f2c86ce
   EXFileSystem: dcf2273f49431e5037347c733a2dc5d08e0d0a9e
@@ -608,16 +616,17 @@ SPEC CHECKSUMS:
   EXPermissions: 8f8c1c05580c4e02d4ee2c8dd74bfe173ff6a723
   FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37
   FBReactNativeSpec: dc7fa9088f0f2a998503a352b0554d69a4391c5a
-  Flipper: 33585e2d9810fe5528346be33bcf71b37bb7ae13
+  Flipper: 1bd2db48dcc31e4b167b9a33ec1df01c2ded4893
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
-  Flipper-Folly: e4493b013c02d9347d5e0cb4d128680239f6c78a
+  Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
-  FlipperKit: bc68102cd4952a258a23c9c1b316c7bec1fecf83
+  Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
+  FlipperKit: 651f50a42eb95c01b3e89a60996dd6aded529eeb
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
+  libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
+  OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   Permission-BluetoothPeripheral: 742b306312f329b809e2f62e475b0b61b206962b
   Permission-LocationWhenInUse: ebef6bf8a123d382f25e9990468cfc8a76fbadf5
   Permission-Notifications: 5b4a12a9b52866667423c93d3af8e43b81872cf4
@@ -666,6 +675,6 @@ SPEC CHECKSUMS:
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: d1cd210d2ec526c73551aa5d838fe8ed61847e19
+PODFILE CHECKSUM: bbfb81792b8f9c85a399d75cb55f86e66d317ab7
 
 COCOAPODS: 1.10.1

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
 				EDC7C74615398FF6972243C8 /* [CP] Copy Pods Resources */,
+				9E9798872129987F84E61CD7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -271,6 +272,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				6C9AF69261402D2CEF042836 /* [CP] Copy Pods Resources */,
+				819D57A3D73D938D2775FC49 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -482,6 +484,24 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example/Pods-example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		819D57A3D73D938D2775FC49 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-example/Pods-example-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example/Pods-example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		8BBE2C85CCB5859B9B163C9B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -524,6 +544,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9E9798872129987F84E61CD7 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-example-exampleTests/Pods-example-exampleTests-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example-exampleTests/Pods-example-exampleTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B49C1DB9CC8B5BEC8E9316DE /* [CP] Check Pods Manifest.lock */ = {

--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
     "react-native-gesture-handler": "^1.10.3",
     "react-native-pager-view": "^5.1.7",
     "react-native-paper": "^4.8.1",
-    "react-native-permissions": "^3.0.4",
+    "react-native-permissions": "^3.0.5",
     "react-native-reanimated": "^2.1.0",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "^3.2.0",

--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
     "react-native-gesture-handler": "^1.10.3",
     "react-native-pager-view": "^5.1.7",
     "react-native-paper": "^4.8.1",
-    "react-native-permissions": "^2.2.0",
+    "react-native-permissions": "^3.0.4",
     "react-native-reanimated": "^2.1.0",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "^3.2.0",

--- a/example/src/ble-data/BaseBleDataSerializer.ts
+++ b/example/src/ble-data/BaseBleDataSerializer.ts
@@ -1,0 +1,16 @@
+export abstract class BaseBleDataSerializer<T> {
+  abstract deserialize(bytes: number[]): T;
+  abstract serialize(data: T): number[];
+
+  protected bitCheck(num: number, bit: number) {
+    // eslint-disable-next-line no-bitwise
+    return (num >> bit) % 2 === 1;
+  }
+
+  protected deserializeDataToUInt16LE(data: number[]): number {
+    const dv = new DataView(new ArrayBuffer(2));
+    dv.setUint8(0, data[0]);
+    dv.setUint8(1, data[1]);
+    return dv.getUint16(0, true);
+  }
+}

--- a/example/src/ble-data/BleTimestamp.ts
+++ b/example/src/ble-data/BleTimestamp.ts
@@ -3,7 +3,7 @@ import {BaseBleDataSerializer} from './BaseBleDataSerializer';
 /**
  * BLE Timestamp をシリアライズ・デシリアライズする
  */
-export class BleTimestampSerializer extends BaseBleDataSerializer<Date> {
+export class BleDateTimeSerializer extends BaseBleDataSerializer<Date> {
   /**
    * 以下の形式のbyte arrayをDateに変換する。year が Little Endianであることを考慮する。
    * |year (16bit)|month(8bit)|day(8bit)|hours(8bit)|minutes(8bit)|seconds(8bit)|

--- a/example/src/ble-data/BleTimestamp.ts
+++ b/example/src/ble-data/BleTimestamp.ts
@@ -1,0 +1,42 @@
+import {BaseBleDataSerializer} from './BaseBleDataSerializer';
+
+/**
+ * BLE Timestamp をシリアライズ・デシリアライズする
+ */
+export class BleTimestampSerializer extends BaseBleDataSerializer<Date> {
+  /**
+   * 以下の形式のbyte arrayをDateに変換する。year が Little Endianであることを考慮する。
+   * |year (16bit)|month(8bit)|day(8bit)|hours(8bit)|minutes(8bit)|seconds(8bit)|
+   */
+  deserialize(bytes: number[]): Date {
+    const [, , month, day, hours, minutes, seconds] = bytes;
+    const year = this.deserializeDataToUInt16LE(bytes.slice(0, 2));
+    return new Date(year, month - 1, day, hours, minutes, seconds);
+  }
+
+  /*
+   * Dateを以下の形式のbyte arrayに変換する。year が Little Endianであることを考慮する。
+   * |year (16bit)|month(8bit)|day(8bit)|hours(8bit)|minutes(8bit)|seconds(8bit)|
+   */
+  serialize(date: Date): number[] {
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const hours = date.getHours();
+    const minutes = date.getMinutes();
+    const seconds = date.getSeconds();
+    const buffer = new ArrayBuffer(2);
+    const dv = new DataView(buffer);
+    dv.setUint16(0, year, true);
+    const serialized = [
+      ...new Uint8Array(buffer),
+      month,
+      day,
+      hours,
+      minutes,
+      seconds,
+    ];
+    //console.log(`serialized: ${JSON.stringify(serialized)}`);
+    return serialized;
+  }
+}

--- a/example/src/ble-data/BleWeightMeasurementSerializer.ts
+++ b/example/src/ble-data/BleWeightMeasurementSerializer.ts
@@ -1,5 +1,5 @@
 import {BaseBleDataSerializer} from './BaseBleDataSerializer';
-import {BleTimestampSerializer} from './BleTimestamp';
+import {BleDateTimeSerializer} from './BleTimestamp';
 
 type BleWeightScaleMeasurementUnit = 'SI' | 'Imperial';
 
@@ -8,7 +8,7 @@ type BleWeightScaleMeasurementUnit = 'SI' | 'Imperial';
  * https://www.bluetooth.com/wp-content/uploads/Sitecore-Media-Library/Gatt/Xml/Characteristics/org.bluetooth.characteristic.weight_measurement.xml
  * https://stackoverflow.com/questions/63771111/bluetooth-low-energy-weight-measurement-characteristic-timestamps
  */
-export type BleDataWeightMeasurment = {
+export type BleWeightMeasurment = {
   flags: {
     measurmentUnits: BleWeightScaleMeasurementUnit;
     timeStampPresent: boolean;
@@ -27,10 +27,10 @@ export type BleDataWeightMeasurment = {
  * BLE 体重測定値をシリアライズ・デシリアライズをする
  * Note: userID, bmi, height に未対応。
  */
-export class BleWeightScaleMeasurementSerializer extends BaseBleDataSerializer<
-  BleDataWeightMeasurment
+export class BleWeightMeasurementSerializer extends BaseBleDataSerializer<
+  BleWeightMeasurment
 > {
-  deserialize(bytes: number[]): BleDataWeightMeasurment {
+  deserialize(bytes: number[]): BleWeightMeasurment {
     const bitFlag = bytes[0];
     const measurmentUnits = this.bitCheck(bitFlag, 0) ? 'Imperial' : 'SI';
     const timeStampPresent = this.bitCheck(bitFlag, 1);
@@ -40,7 +40,7 @@ export class BleWeightScaleMeasurementSerializer extends BaseBleDataSerializer<
       bytes.slice(1, 3),
       measurmentUnits,
     );
-    const timestamp = new BleTimestampSerializer().deserialize(
+    const timestamp = new BleDateTimeSerializer().deserialize(
       bytes.slice(3, 10),
     );
 
@@ -58,7 +58,7 @@ export class BleWeightScaleMeasurementSerializer extends BaseBleDataSerializer<
       height: NaN,
     };
   }
-  serialize(_: BleDataWeightMeasurment): number[] {
+  serialize(_: BleWeightMeasurment): number[] {
     throw new Error('Method not implemented.');
   }
 

--- a/example/src/ble-data/BleWeightScaleMeasurement.ts
+++ b/example/src/ble-data/BleWeightScaleMeasurement.ts
@@ -25,6 +25,7 @@ export type BleDataWeightMeasurment = {
 
 /**
  * BLE 体重測定値をシリアライズ・デシリアライズをする
+ * Note: userID, bmi, height に未対応。
  */
 export class BleWeightScaleMeasurementSerializer extends BaseBleDataSerializer<
   BleDataWeightMeasurment

--- a/example/src/ble-data/BleWeightScaleMeasurement.ts
+++ b/example/src/ble-data/BleWeightScaleMeasurement.ts
@@ -1,0 +1,80 @@
+import {BaseBleDataSerializer} from './BaseBleDataSerializer';
+import {BleTimestampSerializer} from './BleTimestamp';
+
+type BleWeightScaleMeasurementUnit = 'SI' | 'Imperial';
+
+/** BLE Weight Scale Measurement data
+ * ref:
+ * https://www.bluetooth.com/wp-content/uploads/Sitecore-Media-Library/Gatt/Xml/Characteristics/org.bluetooth.characteristic.weight_measurement.xml
+ * https://stackoverflow.com/questions/63771111/bluetooth-low-energy-weight-measurement-characteristic-timestamps
+ */
+export type BleDataWeightMeasurment = {
+  flags: {
+    measurmentUnits: BleWeightScaleMeasurementUnit;
+    timeStampPresent: boolean;
+    userIDPresent: boolean;
+    bmiAndHeightPresent: boolean;
+  };
+  weight: number; // NaN のとき ‘Measurement Unsuccessful’ であることを表す  Ref. [1]
+  timestamp: Date;
+  userID: number;
+  bmi: number;
+  height: number;
+};
+// [1]: The special value of 0xFFFF can be used to indicate ‘Measurement Unsuccessful’ to the Client. If this is used, all optional fields other than the Time Stamp field and the User ID field shall be disabled.
+
+/**
+ * BLE 体重測定値をシリアライズ・デシリアライズをする
+ */
+export class BleWeightScaleMeasurementSerializer extends BaseBleDataSerializer<
+  BleDataWeightMeasurment
+> {
+  deserialize(bytes: number[]): BleDataWeightMeasurment {
+    const bitFlag = bytes[0];
+    const measurmentUnits = this.bitCheck(bitFlag, 0) ? 'Imperial' : 'SI';
+    const timeStampPresent = this.bitCheck(bitFlag, 1);
+    const userIDPresent = this.bitCheck(bitFlag, 2);
+    const bmiAndHeightPresent = this.bitCheck(bitFlag, 3);
+    const weight = this.deserializeWeightValue(
+      bytes.slice(1, 3),
+      measurmentUnits,
+    );
+    const timestamp = new BleTimestampSerializer().deserialize(
+      bytes.slice(3, 10),
+    );
+
+    return {
+      flags: {
+        measurmentUnits,
+        timeStampPresent,
+        userIDPresent,
+        bmiAndHeightPresent,
+      },
+      weight,
+      timestamp,
+      userID: NaN,
+      bmi: NaN,
+      height: NaN,
+    };
+  }
+  serialize(_: BleDataWeightMeasurment): number[] {
+    throw new Error('Method not implemented.');
+  }
+
+  private deserializeWeightValue(
+    weightBytes: number[],
+    measurementUnits: BleWeightScaleMeasurementUnit,
+  ): number {
+    if (weightBytes[0] === 0xff && weightBytes[1] === 0xff) {
+      return NaN;
+    }
+    const weightRawValue = this.deserializeDataToUInt16LE(weightBytes);
+    // Note: A&D UC-352BLEでポンド単位に変更する方法が不明。アカウント設定で変更しても機器に反映されなかった。
+    // resolutionは BLEの体重データ仕様で、単位によって値が変わる。
+    // https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.characteristic.weight.xml
+
+    // unitによって解像度が異なる
+    const resolution = measurementUnits === 'SI' ? 0.005 : 0.01;
+    return weightRawValue * resolution;
+  }
+}

--- a/example/src/ble-data/index.ts
+++ b/example/src/ble-data/index.ts
@@ -1,2 +1,2 @@
 export * from './BleTimestamp';
-export * from './BleWeightScaleMeasurement';
+export * from './BleWeightMeasurementSerializer';

--- a/example/src/ble-data/index.ts
+++ b/example/src/ble-data/index.ts
@@ -1,0 +1,2 @@
+export * from './BleTimestamp';
+export * from './BleWeightScaleMeasurement';

--- a/example/src/screens/BleServiceScreens/AND_UC_352BLEScreen.tsx
+++ b/example/src/screens/BleServiceScreens/AND_UC_352BLEScreen.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {useErrorHandler} from 'react-error-boundary';
+import {useAND_UC_352BLE} from './hooks';
+import {BaseBleServiceScreen} from './BaseBleServiceScreen';
+
+export const AND_UC_352BLEScreen = () => {
+  const handleError = useErrorHandler();
+  const bleController = useAND_UC_352BLE({onError: handleError});
+  return (
+    <BaseBleServiceScreen
+      onError={handleError}
+      onConnectPeripheral={bleController.onConnectPeripheral}
+      characteristicValues={bleController.characteristicValues}
+      receiveCharacteristicValueHandlers={
+        bleController.receiveCharacteristicValueHandlers
+      }
+    />
+  );
+};

--- a/example/src/screens/BleServiceScreens/BaseBleServiceScreen.tsx
+++ b/example/src/screens/BleServiceScreens/BaseBleServiceScreen.tsx
@@ -91,7 +91,7 @@ export const BaseBleServiceScreen: React.VFC<Props> = (props) => {
         await bluevery.init({
           __DEBUG: 'bluevery,bluevery:*',
           onDisconnectPeripheralHandler: (p) => {
-            console.log(`${p.peripheral} is dosconnected`);
+            console.log(`${p.peripheral} is disconnected`);
           },
         });
         await bluevery.startScan({

--- a/example/src/screens/BleServiceScreens/hooks/index.ts
+++ b/example/src/screens/BleServiceScreens/hooks/index.ts
@@ -1,2 +1,3 @@
 export {useAND_UA_651BLE} from './useAND_UA_651BLE';
+export {useAND_UC_352BLE} from './useAND_UC_352BLE';
 export {useBatteryService} from './useBatteryService';

--- a/example/src/screens/BleServiceScreens/hooks/useAND_UA_651BLE.tsx
+++ b/example/src/screens/BleServiceScreens/hooks/useAND_UA_651BLE.tsx
@@ -54,6 +54,7 @@ export const useAND_UA_651BLE: (props: Props) => BleController = ({
               connectParams: [peripheralInfo.id],
               retrieveServicesParams: [peripheralInfo.id],
               retrieveServicesOptions: {
+                omoiyariTime: 3000,
                 retryOptions: {retries: 15},
                 timeoutOptions: {timeoutMilliseconds: 10000},
               },
@@ -84,6 +85,7 @@ export const useAND_UA_651BLE: (props: Props) => BleController = ({
           },
           retrieveServicesParams: [peripheralInfo.id],
           retrieveServicesOptions: {
+            omoiyariTime: 3000,
             retryOptions: {retries: 15},
             timeoutOptions: {timeoutMilliseconds: 10000},
           },

--- a/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
+++ b/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useState} from 'react';
 import {bluevery, PeripheralId, PeripheralInfo} from 'bluevery';
 import {BleController} from './type';
-import {BleWeightScaleMeasurementSerializer} from 'src/ble-data';
+import {BleWeightMeasurementSerializer} from '../../../ble-data';
 
 export const BP_MONITOR_NAME_AND = 'A&D_UC-352BLE';
 export const BP_SERVICE_UUID = '180A';
@@ -105,7 +105,7 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
                 `match the ${peripheralInfo.id} / ${BP_SERVICE_UUID} / ${BP_MEASUREMENT_CHARECTERISTIC_UUID}`,
                 res.value,
               );
-              const serializer = new BleWeightScaleMeasurementSerializer();
+              const serializer = new BleWeightMeasurementSerializer();
               const weightMeasurement = serializer.deserialize(
                 res.value as number[],
               );

--- a/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
+++ b/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useState} from 'react';
 import {bluevery, PeripheralId, PeripheralInfo} from 'bluevery';
 import {BleController} from './type';
+import {BleWeightScaleMeasurementSerializer} from 'src/ble-data';
 
 export const BP_MONITOR_NAME_AND = 'A&D_UC-352BLE';
 export const BP_SERVICE_UUID = '180A';
@@ -100,10 +101,16 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
               res.service.includes(BP_SERVICE_UUID) &&
               res.characteristic.includes(BP_MEASUREMENT_CHARECTERISTIC_UUID)
             ) {
-              // TODO: ここで valueを処理する。ただし、valueは anyになっている
               console.log(
                 `match the ${peripheralInfo.id} / ${BP_SERVICE_UUID} / ${BP_MEASUREMENT_CHARECTERISTIC_UUID}`,
                 res.value,
+              );
+              const serializer = new BleWeightScaleMeasurementSerializer();
+              const weightMeasurement = serializer.deserialize(
+                res.value as number[],
+              );
+              console.log(
+                `weightMeasurement: ${JSON.stringify(weightMeasurement)}`,
               );
               setCharacteristicValues((prev) => {
                 return {

--- a/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
+++ b/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
@@ -100,6 +100,7 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
               res.service.includes(BP_SERVICE_UUID) &&
               res.characteristic.includes(BP_MEASUREMENT_CHARECTERISTIC_UUID)
             ) {
+              // TODO: ここで valueを処理する。ただし、valueは anyになっている
               console.log(
                 `match the ${peripheralInfo.id} / ${BP_SERVICE_UUID} / ${BP_MEASUREMENT_CHARECTERISTIC_UUID}`,
                 res.value,

--- a/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
+++ b/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
@@ -1,0 +1,168 @@
+import {useCallback, useState} from 'react';
+import {bluevery, PeripheralId, PeripheralInfo} from 'bluevery';
+import {BleController} from './type';
+
+export const BP_MONITOR_NAME_AND = 'A&D_UC-352BLE';
+export const BP_SERVICE_UUID = '180A';
+/**
+ * BLE(GATT)のキャラクタリスティックUUID: タイムスタンプ
+ */
+export const BP_DATETIME_CHARECTERISTIC_UUID = '2a08';
+/**
+ * BLE(GATT)のキャラクタリスティックUUID: 体重測定データ
+ */
+export const BP_MEASUREMENT_CHARECTERISTIC_UUID = '2A9D';
+
+/**
+ * Dateを以下の形式のbyte arrayに変換する
+ * |year (16bit)|month(8bit)|day(8bit)|hours(8bit)|minutes(8bit)|seconds(8bit)|
+ */
+export const timeToByteArray = (d: Date) => {
+  const year = d.getFullYear();
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+  const hours = d.getHours();
+  const minutes = d.getMinutes();
+  const seconds = d.getSeconds();
+  const yearData = new Uint8Array(new Uint16Array([year]).buffer); // 16bit -> 8bit array
+
+  const otherData = new Uint8Array([month, day, hours, minutes, seconds]);
+  return [...Array.from(yearData), ...Array.from(otherData)];
+};
+
+/**
+ * hook for A&D_UC-352BLE
+ */
+type Props = {
+  onError: (error: Error) => unknown;
+};
+export const useAND_UC_352BLE: (props: Props) => BleController = ({
+  onError,
+}: Props) => {
+  const [characteristicValues, setCharacteristicValues] = useState<
+    {
+      [K in PeripheralId]: unknown[];
+    }
+  >({});
+
+  const onReceiveCharacteristicValue = useCallback(
+    async (peripheralInfo: PeripheralInfo) => {
+      try {
+        await bluevery.receiveCharacteristicValue({
+          onCallBeforeStartNotification: async () => {
+            await bluevery.connect({
+              connectParams: [peripheralInfo.id],
+              retrieveServicesParams: [peripheralInfo.id],
+              retrieveServicesOptions: {
+                retryOptions: {retries: 15},
+                timeoutOptions: {timeoutMilliseconds: 10000},
+              },
+              bondingParams: [peripheralInfo.id, peripheralInfo.id],
+            });
+            await bluevery.writeValue({
+              writeValueParams: [
+                peripheralInfo.id,
+                BP_SERVICE_UUID,
+                BP_DATETIME_CHARECTERISTIC_UUID,
+                timeToByteArray(new Date()),
+              ],
+              retrieveServicesParams: [peripheralInfo.id],
+            });
+            // Note: readする必要はある？
+            await bluevery.readValue({
+              readValueParams: [
+                peripheralInfo.id,
+                BP_SERVICE_UUID,
+                BP_DATETIME_CHARECTERISTIC_UUID,
+              ],
+              retrieveServicesParams: [peripheralInfo.id],
+            });
+          },
+          scanParams: {
+            scanOptions: {
+              scanningSettings: [[], 1, true],
+            },
+          },
+          retrieveServicesParams: [peripheralInfo.id],
+          retrieveServicesOptions: {
+            retryOptions: {retries: 15},
+            timeoutOptions: {timeoutMilliseconds: 10000},
+          },
+          startNotificationParams: [
+            peripheralInfo.id,
+            BP_SERVICE_UUID,
+            BP_MEASUREMENT_CHARECTERISTIC_UUID,
+          ],
+          receiveCharacteristicHandler: (res) => {
+            console.log('global subscribed: receiveCharacteristic', {...res});
+            if (
+              res.peripheral === peripheralInfo.id &&
+              res.service.includes(BP_SERVICE_UUID) &&
+              res.characteristic.includes(BP_MEASUREMENT_CHARECTERISTIC_UUID)
+            ) {
+              console.log(
+                `match the ${peripheralInfo.id} / ${BP_SERVICE_UUID} / ${BP_MEASUREMENT_CHARECTERISTIC_UUID}`,
+                res.value,
+              );
+              setCharacteristicValues((prev) => {
+                return {
+                  ...prev,
+                  [res.peripheral]: [
+                    ...(prev[res.peripheral] || []),
+                    res.value,
+                  ],
+                };
+              });
+            }
+          },
+        });
+      } catch (error) {
+        onError(error);
+      }
+    },
+    [onError],
+  );
+
+  const onConnectPeripheral = useCallback(
+    async (peripheralInfo: PeripheralInfo) => {
+      try {
+        await bluevery.connect({
+          connectParams: [peripheralInfo.id],
+          retrieveServicesParams: [peripheralInfo.id],
+          bondingParams: [peripheralInfo.id, peripheralInfo.id],
+        });
+        await bluevery.writeValue({
+          writeValueParams: [
+            peripheralInfo.id,
+            BP_SERVICE_UUID,
+            BP_DATETIME_CHARECTERISTIC_UUID,
+            timeToByteArray(new Date()),
+          ],
+          retrieveServicesParams: [peripheralInfo.id],
+        });
+        await bluevery.readValue({
+          readValueParams: [
+            peripheralInfo.id,
+            BP_SERVICE_UUID,
+            BP_DATETIME_CHARECTERISTIC_UUID,
+          ],
+          retrieveServicesParams: [peripheralInfo.id],
+        });
+      } catch (error) {
+        onError(error);
+      }
+    },
+    [onError],
+  );
+
+  return {
+    receiveCharacteristicValueHandlers: {
+      [BP_MONITOR_NAME_AND]: {
+        name: BP_MONITOR_NAME_AND,
+        onReceiveCharacteristicValue,
+      },
+    },
+    onConnectPeripheral,
+    characteristicValues,
+  };
+};

--- a/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
+++ b/example/src/screens/BleServiceScreens/hooks/useAND_UC_352BLE.tsx
@@ -4,7 +4,7 @@ import {BleController} from './type';
 import {BleWeightMeasurementSerializer} from '../../../ble-data';
 
 export const BP_MONITOR_NAME_AND = 'A&D_UC-352BLE';
-export const BP_SERVICE_UUID = '180A';
+export const BP_SERVICE_UUID = '181D';
 /**
  * BLE(GATT)のキャラクタリスティックUUID: タイムスタンプ
  */
@@ -48,13 +48,16 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
 
   const onReceiveCharacteristicValue = useCallback(
     async (peripheralInfo: PeripheralInfo) => {
+      console.log('onReceiveCharacteristicValue');
       try {
         await bluevery.receiveCharacteristicValue({
           onCallBeforeStartNotification: async () => {
+            await bluevery.stopScan();
             await bluevery.connect({
               connectParams: [peripheralInfo.id],
               retrieveServicesParams: [peripheralInfo.id],
               retrieveServicesOptions: {
+                omoiyariTime: 3000,
                 retryOptions: {retries: 15},
                 timeoutOptions: {timeoutMilliseconds: 10000},
               },
@@ -78,6 +81,7 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
               ],
               retrieveServicesParams: [peripheralInfo.id],
             });
+            //await bluevery.disconnect(peripheralInfo.id);
           },
           scanParams: {
             scanOptions: {
@@ -86,6 +90,7 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
           },
           retrieveServicesParams: [peripheralInfo.id],
           retrieveServicesOptions: {
+            omoiyariTime: 3000,
             retryOptions: {retries: 15},
             timeoutOptions: {timeoutMilliseconds: 10000},
           },
@@ -134,11 +139,13 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
   const onConnectPeripheral = useCallback(
     async (peripheralInfo: PeripheralInfo) => {
       try {
+        console.log(`start connect`);
         await bluevery.connect({
           connectParams: [peripheralInfo.id],
           retrieveServicesParams: [peripheralInfo.id],
           bondingParams: [peripheralInfo.id, peripheralInfo.id],
         });
+        console.log(`end connect`);
         await bluevery.writeValue({
           writeValueParams: [
             peripheralInfo.id,
@@ -148,7 +155,8 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
           ],
           retrieveServicesParams: [peripheralInfo.id],
         });
-        await bluevery.readValue({
+        console.log(`reade value: end write value`);
+        const value = await bluevery.readValue({
           readValueParams: [
             peripheralInfo.id,
             BP_SERVICE_UUID,
@@ -156,6 +164,7 @@ export const useAND_UC_352BLE: (props: Props) => BleController = ({
           ],
           retrieveServicesParams: [peripheralInfo.id],
         });
+        console.log(`reade value: ${JSON.stringify(value)}`);
       } catch (error) {
         onError(error);
       }

--- a/example/src/screens/BleServiceScreens/index.ts
+++ b/example/src/screens/BleServiceScreens/index.ts
@@ -1,7 +1,9 @@
 import {BatteryServiceScreen} from './BatteryServiceScreen';
 import {AND_UA_651BLEScreen} from './AND_UA_651BLEScreen';
+import {AND_UC_352BLEScreen} from './AND_UC_352BLEScreen';
 
 export const BleServiceScreens = {
-  AND_UA_651BLE: AND_UA_651BLEScreen,
+  'AND UA-651BLE': AND_UA_651BLEScreen,
+  'AND UC-352BLE': AND_UC_352BLEScreen,
   BatteryService: BatteryServiceScreen,
 };

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -7957,10 +7957,10 @@ react-native-paper@^4.8.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-permissions@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-2.2.2.tgz#3d2a63f6b7d6be52fc86e30f77412a9566283028"
-  integrity sha512-ihf4shQDSX5Oo9ChQXb9kr13mmyyNem5MaEvOpr3dCjhBOBWyEMztXm9/uPK1Qg5PsNpaYLa1KpcPZDCw87LXg==
+react-native-permissions@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.4.tgz#7771d28899d7d2b75fd2a70cd3f86d44c90397ec"
+  integrity sha512-GMd0l0TA/qupidGFfKAVNaboewQkJSW+l3ndwv1cu+tBGI+TRfJdMjg8Q714wn9roZlXsZ3z407qT2xPdQmGdg==
 
 react-native-reanimated@^2.1.0:
   version "2.1.0"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -7957,10 +7957,10 @@ react-native-paper@^4.8.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-permissions@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.4.tgz#7771d28899d7d2b75fd2a70cd3f86d44c90397ec"
-  integrity sha512-GMd0l0TA/qupidGFfKAVNaboewQkJSW+l3ndwv1cu+tBGI+TRfJdMjg8Q714wn9roZlXsZ3z407qT2xPdQmGdg==
+react-native-permissions@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.5.tgz#94542a343abdac801fa0a4593ea2c751cb45c41f"
+  integrity sha512-hcvLtHhTyOTXC+CCv79d4Qtdnj6PGuY5Ms0fhW8V6Et1T/mPvzO6++Du4jwEv/oHZ62qMWKUDq0/Tsh63QHuyQ==
 
 react-native-reanimated@^2.1.0:
   version "2.1.0"

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "p-tap": "^3.1.0",
     "p-timeout": "^5.0.0",
     "react-native-ble-manager": "^7.3.1",
-    "react-native-permissions": "^2.2.0",
+    "react-native-permissions": "^3.0.4",
     "valtio": "^1.0.0"
   },
   "peerDependencies": {
     "react": "16.13.1",
     "react-native": "0.63.2",
     "react-native-ble-manager": "^7.3.1",
-    "react-native-permissions": "^2.2.0"
+    "react-native-permissions": "^3.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "p-tap": "^3.1.0",
     "p-timeout": "^5.0.0",
     "react-native-ble-manager": "^7.3.1",
-    "react-native-permissions": "^3.0.4",
+    "react-native-permissions": "^3.0.5",
     "valtio": "^1.0.0"
   },
   "peerDependencies": {
     "react": "16.13.1",
     "react-native": "0.63.2",
     "react-native-ble-manager": "^7.3.1",
-    "react-native-permissions": "^3.0.4"
+    "react-native-permissions": "^3.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/libs/checkPermission.test.ts
+++ b/src/libs/checkPermission.test.ts
@@ -65,14 +65,14 @@ describe('checkPermission', () => {
     test('Android: should be return tuple(granted & others): both granted', async () => {
       mockPlatform('android', 10);
       mockCheckMultiple({
-        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: 'granted',
-        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION]: 'granted',
+        'android.permission.ACCESS_FINE_LOCATION': 'granted',
+        'android.permission.ACCESS_COARSE_LOCATION': 'granted',
       });
       const checked = await checkPermission();
       expect(checked).toStrictEqual([
         [
-          PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
-          PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION,
+          'android.permission.ACCESS_FINE_LOCATION',
+          'android.permission.ACCESS_COARSE_LOCATION',
         ],
         [],
       ]);
@@ -81,28 +81,28 @@ describe('checkPermission', () => {
     test('Android: should be return tuple(granted & others): one side each', async () => {
       mockPlatform('android', 10);
       mockCheckMultiple({
-        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: 'granted',
-        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION]: 'denied',
+        'android.permission.ACCESS_FINE_LOCATION': 'granted',
+        'android.permission.ACCESS_COARSE_LOCATION': 'denied',
       });
       const checked = await checkPermission();
       expect(checked).toStrictEqual([
-        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION],
-        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION],
+        ['android.permission.ACCESS_FINE_LOCATION'],
+        ['android.permission.ACCESS_COARSE_LOCATION'],
       ]);
     });
 
     test('Android: should be return tuple(granted & others): both not granted', async () => {
       mockPlatform('android', 10);
       mockCheckMultiple({
-        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: 'blocked',
-        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION]: 'blocked',
+        'android.permission.ACCESS_FINE_LOCATION': 'blocked',
+        'android.permission.ACCESS_COARSE_LOCATION': 'blocked',
       });
       const checked = await checkPermission();
       expect(checked).toStrictEqual([
         [],
         [
-          PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
-          PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION,
+          'android.permission.ACCESS_FINE_LOCATION',
+          'android.permission.ACCESS_COARSE_LOCATION',
         ],
       ]);
     });

--- a/src/libs/checkPermission.test.ts
+++ b/src/libs/checkPermission.test.ts
@@ -1,9 +1,5 @@
-import {
-  PERMISSIONS,
-  RESULTS,
-  Permission,
-  checkMultiple,
-} from 'react-native-permissions';
+import {RESULTS, Permission, checkMultiple} from 'react-native-permissions';
+import {PERMISSIONS} from 'react-native-permissions/mock';
 import {checkPermission} from './checkPermission';
 import {mockPlatform} from '../../__tests__/__utils__/mockPlatform';
 
@@ -65,14 +61,14 @@ describe('checkPermission', () => {
     test('Android: should be return tuple(granted & others): both granted', async () => {
       mockPlatform('android', 10);
       mockCheckMultiple({
-        'android.permission.ACCESS_FINE_LOCATION': 'granted',
-        'android.permission.ACCESS_COARSE_LOCATION': 'granted',
+        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: 'granted',
+        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION]: 'granted',
       });
       const checked = await checkPermission();
       expect(checked).toStrictEqual([
         [
-          'android.permission.ACCESS_FINE_LOCATION',
-          'android.permission.ACCESS_COARSE_LOCATION',
+          PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
+          PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION,
         ],
         [],
       ]);
@@ -81,28 +77,28 @@ describe('checkPermission', () => {
     test('Android: should be return tuple(granted & others): one side each', async () => {
       mockPlatform('android', 10);
       mockCheckMultiple({
-        'android.permission.ACCESS_FINE_LOCATION': 'granted',
-        'android.permission.ACCESS_COARSE_LOCATION': 'denied',
+        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: 'granted',
+        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION]: 'denied',
       });
       const checked = await checkPermission();
       expect(checked).toStrictEqual([
-        ['android.permission.ACCESS_FINE_LOCATION'],
-        ['android.permission.ACCESS_COARSE_LOCATION'],
+        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION],
+        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION],
       ]);
     });
 
     test('Android: should be return tuple(granted & others): both not granted', async () => {
       mockPlatform('android', 10);
       mockCheckMultiple({
-        'android.permission.ACCESS_FINE_LOCATION': 'blocked',
-        'android.permission.ACCESS_COARSE_LOCATION': 'blocked',
+        [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: 'blocked',
+        [PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION]: 'blocked',
       });
       const checked = await checkPermission();
       expect(checked).toStrictEqual([
         [],
         [
-          'android.permission.ACCESS_FINE_LOCATION',
-          'android.permission.ACCESS_COARSE_LOCATION',
+          PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
+          PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION,
         ],
       ]);
     });

--- a/src/libs/checkPermission.ts
+++ b/src/libs/checkPermission.ts
@@ -15,10 +15,10 @@ export async function checkPermission(): Promise<
        * Android < 10では、ACCESS_FINE_LOCATIONが必要
        * https://developer.android.com/guide/topics/connectivity/bluetooth?hl=ja
        */
-      PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
-      PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION,
+      'android.permission.ACCESS_FINE_LOCATION',
+      'android.permission.ACCESS_COARSE_LOCATION',
     ],
-  });
+  }) as Permission[];
   if (!permissionTargets) {
     throw Error('permission targets not found');
   }

--- a/src/libs/checkPermission.ts
+++ b/src/libs/checkPermission.ts
@@ -8,17 +8,17 @@ import RNPermissions, {
 export async function checkPermission(): Promise<
   [granted: Permission[], ungranted: Permission[]]
 > {
-  const permissionTargets = Platform.select({
+  const permissionTargets = Platform.select<Permission[]>({
     ios: [PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL],
     android: [
       /**
        * Android < 10では、ACCESS_FINE_LOCATIONが必要
        * https://developer.android.com/guide/topics/connectivity/bluetooth?hl=ja
        */
-      'android.permission.ACCESS_FINE_LOCATION',
-      'android.permission.ACCESS_COARSE_LOCATION',
+      PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
+      PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION,
     ],
-  }) as Permission[];
+  });
   if (!permissionTargets) {
     throw Error('permission targets not found');
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6521,10 +6521,10 @@ react-native-ble-manager@^7.3.1:
   resolved "https://registry.yarnpkg.com/react-native-ble-manager/-/react-native-ble-manager-7.4.1.tgz#062c13614e0e627a4d2648075716e02938d44a13"
   integrity sha512-d9VS9y11SKxU6eUBIlUYrGo3kJKtGfuLJ4eDV7corETARz8JRWd5a/lXO5uqvyNP2lV5w3SiuycOJXEZdX7sow==
 
-react-native-permissions@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-2.2.2.tgz#3d2a63f6b7d6be52fc86e30f77412a9566283028"
-  integrity sha512-ihf4shQDSX5Oo9ChQXb9kr13mmyyNem5MaEvOpr3dCjhBOBWyEMztXm9/uPK1Qg5PsNpaYLa1KpcPZDCw87LXg==
+react-native-permissions@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.4.tgz#7771d28899d7d2b75fd2a70cd3f86d44c90397ec"
+  integrity sha512-GMd0l0TA/qupidGFfKAVNaboewQkJSW+l3ndwv1cu+tBGI+TRfJdMjg8Q714wn9roZlXsZ3z407qT2xPdQmGdg==
 
 react-native@0.63.2:
   version "0.63.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6521,10 +6521,10 @@ react-native-ble-manager@^7.3.1:
   resolved "https://registry.yarnpkg.com/react-native-ble-manager/-/react-native-ble-manager-7.4.1.tgz#062c13614e0e627a4d2648075716e02938d44a13"
   integrity sha512-d9VS9y11SKxU6eUBIlUYrGo3kJKtGfuLJ4eDV7corETARz8JRWd5a/lXO5uqvyNP2lV5w3SiuycOJXEZdX7sow==
 
-react-native-permissions@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.4.tgz#7771d28899d7d2b75fd2a70cd3f86d44c90397ec"
-  integrity sha512-GMd0l0TA/qupidGFfKAVNaboewQkJSW+l3ndwv1cu+tBGI+TRfJdMjg8Q714wn9roZlXsZ3z407qT2xPdQmGdg==
+react-native-permissions@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.5.tgz#94542a343abdac801fa0a4593ea2c751cb45c41f"
+  integrity sha512-hcvLtHhTyOTXC+CCv79d4Qtdnj6PGuY5Ms0fhW8V6Et1T/mPvzO6++Du4jwEv/oHZ62qMWKUDq0/Tsh63QHuyQ==
 
 react-native@0.63.2:
   version "0.63.2"


### PR DESCRIPTION
# Issue
#54 

# 修正内容
- A&D UC-352BLE用の Exampleを追加した
- Omoiyari Timer用のインターフェース追加に対応するため、useAND_UA_651BLE を修正した
- react-native-permissions v3 にアップデートした
  - 新しい Xcodeでビルドできるようにするため
  - なお、v3 から Permissionsの定義値が変更になっているようで、テストでエラーになっていたため、checkPermissionの一部のテストと実装を修正した


# 補足: react-native-permissions v3 のPermissionsの定義値に関する修正について

Exampleのみ追加するつもりでしたが、react-native-permissionのバージョンを上げた副作用でテストが失敗していたため修正しました。
以下はやっつけ感のある対応だと思うので、不十分なようでしたら修正します 🙏 

##  現象
  checkPermssionsのテストが iOSの Permissionについてはパスするが、Androidの PermissionについてはNGであった。

## 原因
  Permissions.Androidの値が空値 {}になっていた。
  react-native-permissions v3 と v2の差分を見ると、v2 では Permissionが定数値で iOSや Androidともすべて値が定義されていたが、 v3 では、デフォルトの permissions.ts では Permission の値は iOS, Android, Windows どれも{}が値として定義されていた。プラットフォーム固有の permissions.ios.ts, permissions.android.ts では対応するプラットフォーム用のための定義だけがされるように変更されていた。
Jestの実行時は Platformが iOSとして認識されていたため、Andoroidでのみ問題が起きていたと思われる。

## 対策
最低限の対応として、Androidに関しては Platforms.Android ではなく、実際の定義値を直接埋め込む形に修正した。


 ## 参照
- https://github.com/zoontek/react-native-permissions/blob/master/src/permissions.ts
-  https://github.com/zoontek/react-native-permissions/blob/master/src/permissions.ios.ts
- https://github.com/zoontek/react-native-permissions/blob/master/src/permissions.android.ts