### PR TITLE
fix: suppress initAndScan on BaseBleServiceScreen

### DIFF
--- a/example/src/screens/BleServiceScreens/BaseBleServiceScreen.tsx
+++ b/example/src/screens/BleServiceScreens/BaseBleServiceScreen.tsx
@@ -115,7 +115,9 @@ export const BaseBleServiceScreen: React.VFC<Props> = (props) => {
       console.log('cleanup: initAndScan');
       bluevery.stopBluevery();
     };
-  }, [props]);
+    // propsをdepsに含めると、receiveCharacteristicValueしたときにここのeffectが走ってしまうので1回だけに絞る
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <SafeAreaView style={styles.mainContentContainer}>


### PR DESCRIPTION
fix #53 

useEffectのdepsにpropsが入っているゆえに、`receiveCharacteristicValue`したときに `initAndScan` が再発火してしまうのが原因でした。